### PR TITLE
Configure deployment to GH Pages 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,58 @@
+name: Deploy to GitHub pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Setup Node.JS
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        env:
+          BRIDGETOWN_ENV: production
+        run: bin/bridgetown deploy
+
+      - name: Upload build artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./output
+
+  deploy:
+    needs: build
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: production
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   bridgetown (~> 1.3.1)

--- a/bridgetown.config.yml
+++ b/bridgetown.config.yml
@@ -4,7 +4,7 @@ url: "https://olivierobert.com/"
 permalink: pretty
 template_engine: liquid
 
-# timezone: America/Los_Angeles
+timezone: Europe/Paris
 
 # pagination:
 #   enabled: true


### PR DESCRIPTION
## What Changed 🆕

Add a new GH Action workflow to deploy to GH pages.

## Insight 💡

The [required DNS records](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site) were added: 

<img width="1073" alt="image" src="https://github.com/olivierobert/olivierobert-web/assets/696529/488bfd56-714d-4218-891e-0340ea40f179">

The domain has been verified:

<img width="963" alt="image" src="https://github.com/olivierobert/olivierobert-web/assets/696529/0319217e-2b44-44ae-9353-ff14584393d1">


## Proof Of Work ✨

Since a workflow dispatch is not implemented, it will be tested upon merging the PR 🪀 